### PR TITLE
Update Docker image name in Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         stage('Build') { 
             steps { 
                 script{
-                 app = docker.build("cc-backend:${env.BUILD_NUMBER}")
+                 app = docker.build("cc-cases:${env.BUILD_NUMBER}")
                 }
             }
         }
@@ -55,7 +55,7 @@ pipeline {
             steps {
                 script {
                     echo "Run Trivy Image Scanner"
-                    sh "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image cc-backend:${env.BUILD_NUMBER}"
+                    sh "docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image cc-cases:${env.BUILD_NUMBER}"
                 }
             }
         }


### PR DESCRIPTION
The Docker image name has been updated from `cc-backend` to `cc-cases` in the Jenkins pipeline configuration. This change affects both the build step, where the Docker image is tagged, and the Trivy image scan step, ensuring the security scanning is performed on the correctly tagged image.